### PR TITLE
GNOME 42 wallpaper and switcher fixes

### DIFF
--- a/navigator.js
+++ b/navigator.js
@@ -49,17 +49,15 @@ var grab = false;
 var ActionDispatcher = class {
   constructor() {
     this.actor = new Clutter.Actor();
+    this.actor.set_flags(Clutter.ActorFlags.REACTIVE);
     Main.uiGroup.add_actor(this.actor);
-    if (!Main.pushModal(this.actor)) {
-      // Probably someone else has a pointer grab, try again with keyboard only
-      if (
-        !Main.pushModal(this.actor, {
-          options: Meta.ModalOptions.POINTER_ALREADY_GRABBED,
-        })
-      )
-        throw new Error("Could not grap a modal");
+    let tempGrab = Main.pushModal(this.actor);
+    // We expect at least a keyboard grab here
+    if ((tempGrab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
+        Main.popModal(tempGrab);
+        return false;
     }
-    grab = true;
+    grab = tempGrab;
 
     this.actor.connect("key-press-event", this._keyPressEvent.bind(this));
     this.actor.connect("key-release-event", this._keyReleaseEvent.bind(this));
@@ -197,10 +195,10 @@ var ActionDispatcher = class {
   }
 
   destroy() {
-    grab = false;
     if (this._noModsTimeoutId != 0)
       Mainloop.source_remove(this._noModsTimeoutId);
-    Main.popModal(this.actor);
+    Main.popModal(grab);
+    grab = false;
     this.actor.destroy();
     this.actor = null;
     // We have already destroyed the navigator

--- a/tiling.js
+++ b/tiling.js
@@ -41,6 +41,9 @@ var prefs = Settings.prefs;
 var backgroundSettings = new Gio.Settings({
   schema_id: "org.gnome.desktop.background",
 });
+var interfaceSettings = new Gio.Settings({
+  schema_id: "org.gnome.desktop.interface",
+});
 
 var borderWidth = 8;
 // Mutter prevints windows from being placed further off the screen than 75 pixels.
@@ -240,6 +243,11 @@ class Space extends Array {
     const Convenience = Extension.imports.convenience;
     const settings = Convenience.getSettings();
     this.signals.connect(
+      interfaceSettings,
+      "changed::color-scheme",
+      this.updateBackground.bind(this)
+    );
+    this.signals.connect(
       settings,
       "changed::default-background",
       this.updateBackground.bind(this)
@@ -252,6 +260,11 @@ class Space extends Array {
     this.signals.connect(
       backgroundSettings,
       "changed::picture-uri",
+      this.updateBackground.bind(this)
+    );
+    this.signals.connect(
+      backgroundSettings,
+      "changed::picture-uri-dark",
       this.updateBackground.bind(this)
     );
   }
@@ -1132,7 +1145,11 @@ box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, .7);
     const BackgroundStyle = imports.gi.GDesktopEnums.BackgroundStyle;
     let style = BackgroundStyle.ZOOM;
     if (!path && useDefault) {
-      path = backgroundSettings.get_string("picture-uri");
+      if (interfaceSettings.get_string("color-scheme") === "default") {
+        path = backgroundSettings.get_string("picture-uri");
+      } else {
+        path = backgroundSettings.get_string("picture-uri-dark");
+      }
     }
 
     let file = Gio.File.new_for_commandline_arg(path);

--- a/topbar.js
+++ b/topbar.js
@@ -588,16 +588,20 @@ function enable() {
       space.label.clutter_text.set_font_description(fontDescription);
     }
   }
+  // TheSola10: drop the modified Activities button since D2P can't
+  /*
   Main.panel.addToStatusArea("WorkspaceMenu", menu, 0, "left");
   menu.actor.show();
+  */
 
-  // Force transparency
+  // Force transparency (wtf? that's out of scope)
+  /*
   panel.set_style("background-color: rgba(0, 0, 0, 0.35);");
   if ("_rightCorner" in Main.panel)
     [Main.panel._rightCorner, Main.panel._leftCorner].forEach(
       (c) => (c.actor.opacity = 0)
     );
-
+  */
   screenSignals.push(
     workspaceManager.connect_after(
       "workspace-switched",


### PR DESCRIPTION
I applied fixes discussed in your PR, in addition to a fix that allows PaperWM to detect dark/light wallpaper changes using GNOME 42's new colorscheme attribute