### PR TITLE
Fixed crash on new window starting on scratch layer

### DIFF
--- a/scratch.js
+++ b/scratch.js
@@ -73,9 +73,11 @@ function makeScratch(metaWindow) {
     // Figure out some stuff before the window is removed from the tiling
     let space = Tiling.spaces.spaceOfWindow(metaWindow);
     fromTiling = space.indexOf(metaWindow) > -1;
-    windowPositionSeen = metaWindow.clone
-      .get_transformed_position()
-      .map(Math.round);
+    if (fromTiling) {
+      windowPositionSeen = metaWindow.clone
+        .get_transformed_position()
+        .map(Math.round);
+    }
   }
 
   metaWindow[float] = true;


### PR DESCRIPTION
This fixes a long-standing bug where GNOME in its entirety would segfault when opening a new scratch window using a user rule.